### PR TITLE
장바구니 상품 수량 변경

### DIFF
--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -1,0 +1,18 @@
+const cartService = require("../services/cartService");
+const { catchAsync, raiseCustomError } = require("../utils/error");
+
+const modifyQuantity = catchAsync(async (req, res) => {
+  const userId = req.user.id;
+  const productId = req.params.productId;
+  const { quantity } = req.body;
+
+  if (!productId) {
+    raiseCustomError(KEY_ERROR, 400);
+  }
+
+  await cartService.modifyQuantity(userId, productId, quantity);
+
+  return res.status(201).json({ message: "quantityModified" });
+});
+
+module.exports = { modifyQuantity };

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -1,0 +1,20 @@
+const { database } = require("./dataSource");
+const { raiseCustomError } = require("../utils/error");
+
+const modifyQuantity = async (quantity, userId, productId) => {
+  try {
+    return await database.query(
+      `UPDATE
+          carts
+        SET
+          quantity =?
+        WHERE user_id =? AND product_id = ?
+          `,
+      [quantity, userId, productId]
+    );
+  } catch (err) {
+    raiseCustomError("INVALID_DATA_INPUT", 500);
+  }
+};
+
+module.exports = { modifyQuantity };

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -1,7 +1,7 @@
 const { database } = require("./dataSource");
 const { raiseCustomError } = require("../utils/error");
 
-const modifyQuantity = async (quantity, userId, productId) => {
+const modifyQuantity = async (userId, productId, quantity) => {
   try {
     return await database.query(
       `UPDATE

--- a/routes/cartRouter.js
+++ b/routes/cartRouter.js
@@ -1,0 +1,10 @@
+const express = require("express");
+
+const cartController = require("../controllers/cartController");
+const { loginRequired } = require("../utils/checkUser");
+
+const router = express.Router();
+
+router.patch("/:productId", loginRequired, cartController.modifyQuantity);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,8 +4,10 @@ const router = express.Router();
 
 const userRouter = require("./userRouter");
 const lectureRouter = require("./lectureRouter");
+const cartRouter = require("./cartRouter");
 
 router.use("/users", userRouter);
 router.use("/lecture", lectureRouter);
+router.use("/cart", cartRouter);
 
 module.exports = router;

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -1,0 +1,12 @@
+const cartDao = require("../models/cartDao");
+const { raiseCustomError } = require("../utils/error");
+
+const modifyQuantity = async (userId, productId, quantity) => {
+  if (quantity > 7) {
+    raiseCustomError("too Many products", 409);
+  }
+
+  return await cartDao.modifyQuantity(userId, productId, quantity);
+};
+
+module.exports = { modifyQuantity };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 장바구니에 담긴 상품 수량 변경 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. user_id -> 토큰에서 받아오기
2. product_id -> usestate에 저장된 값 받아오기
3. 수량은 7개 까지만 늘릴 수 있게 구현
  → 너무 많은 수량을 넣지 못하게 막아놓음 (무한 클릭 시 서버가 터질 수 있다고 생각)


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 구매자에 입장에서 장바구니 기능을 생각해보니, 복잡한 로직을 구현하는 것은 서버의 response 속도를 느리게 하는 안좋은 일이라는 것을 알게되고, 간단하게 생각을 해야겠다고 고찰했습니다.

<br />

## :: 기타 질문 및 특이 사항

- 다음번에는 장바구니 수량을 변경할 때 팝업창을 띄우고 수정을 하면 좋겠다고 생각했습니다. (like naver)
